### PR TITLE
Improved error checking and other tweaks

### DIFF
--- a/src/ADXL345_WE.cpp
+++ b/src/ADXL345_WE.cpp
@@ -49,8 +49,9 @@ bool ADXL345_WE::init(){
     angleOffsetVal = {0.0, 0.0, 0.0};
     writeRegister(ADXL345_DATA_FORMAT,0); 
     setFullRes(true); 
-    uint8_t ctrlVal = readRegister8(ADXL345_DATA_FORMAT);
-    if(ctrlVal != 0b1000){
+    uint8_t ctrlVal; 
+    bool ok = readRegister8(ADXL345_DATA_FORMAT, &ctrlVal);
+    if(!ok || ctrlVal != 0b1000){
         return false;
     }
     writeRegister(ADXL345_INT_ENABLE, 0);
@@ -84,23 +85,28 @@ void ADXL345_WE::setCorrFactors(float xMin, float xMax, float yMin, float yMax, 
     offsetVal.z = (zMax + zMin) * 0.5;
 }
 
-void ADXL345_WE::setDataRate(adxl345_dataRate rate){
-    regVal = readRegister8(ADXL345_BW_RATE);
+bool ADXL345_WE::setDataRate(adxl345_dataRate rate){
+    if (!readRegister8(ADXL345_BW_RATE, &regVal) || rate == ADXL345_DATA_RATE_ERROR) {
+        return false;
+    }
     regVal &= 0xF0;
     regVal |= rate;
     writeRegister(ADXL345_BW_RATE, regVal);
+    return true;
 }
     
 adxl345_dataRate ADXL345_WE::getDataRate(){
-    return (adxl345_dataRate)(readRegister8(ADXL345_BW_RATE) & 0x0F);
+    if (!readRegister8(ADXL345_BW_RATE, &regVal)) {
+        return ADXL345_DATA_RATE_ERROR;
+    }
+    return (adxl345_dataRate)(regVal & 0x0F);
 }
 
 
 String ADXL345_WE::getDataRateAsString(){
-    adxl345_dataRate dataRate = (adxl345_dataRate)(readRegister8(ADXL345_BW_RATE) & 0x0F);
-    String returnString = "";
-    
+    adxl345_dataRate dataRate = getDataRate();    
     switch(dataRate) {
+        case ADXL345_DATA_RATE_ERROR: return(F("ERROR")); break;
         case ADXL345_DATA_RATE_3200: return(F("3200 Hz")); break;
         case ADXL345_DATA_RATE_1600: return(F("1600 Hz")); break;
         case ADXL345_DATA_RATE_800:  return(F("800 Hz"));  break;
@@ -121,14 +127,13 @@ String ADXL345_WE::getDataRateAsString(){
     }
 }
 
-uint8_t ADXL345_WE::getPowerCtlReg(){
-    return readRegister8(ADXL345_POWER_CTL);
-}
-
-void ADXL345_WE::setRange(adxl345_range range){
-    uint8_t regVal = readRegister8(ADXL345_DATA_FORMAT);
+bool ADXL345_WE::setRange(adxl345_range range){
+    if (!readRegister8(ADXL345_DATA_FORMAT, &regVal) || range == ADXL345_RANGE_ERROR) {
+        return false;
+    }
     if(adxl345_lowRes){
         switch(range){
+            case ADXL345_RANGE_ERROR: return false; break; // Already handled, but avoids compiler warning
             case ADXL345_RANGE_2G:  rangeFactor = 1.0;  break;
             case ADXL345_RANGE_4G:  rangeFactor = 2.0;  break;
             case ADXL345_RANGE_8G:  rangeFactor = 4.0;  break;
@@ -141,16 +146,21 @@ void ADXL345_WE::setRange(adxl345_range range){
     regVal &= 0b11111100;
     regVal |= range;
     writeRegister(ADXL345_DATA_FORMAT, regVal);
+    return true;
 }
 
 adxl345_range ADXL345_WE::getRange(){
-    regVal = readRegister8(ADXL345_DATA_FORMAT);
+    if (!readRegister8(ADXL345_DATA_FORMAT, &regVal)) {
+        return ADXL345_RANGE_ERROR;
+    }
     regVal &= 0x03; 
     return adxl345_range(regVal);
 }
 
-void ADXL345_WE::setFullRes(bool full){
-    regVal = readRegister8(ADXL345_DATA_FORMAT);
+bool ADXL345_WE::setFullRes(bool full){
+    if (!readRegister8(ADXL345_DATA_FORMAT, &regVal)) {
+        return false;
+    }
     if(full){
         adxl345_lowRes = false;
         rangeFactor = 1.0;
@@ -159,14 +169,18 @@ void ADXL345_WE::setFullRes(bool full){
     else{
         adxl345_lowRes = true;
         regVal &= ~(1<<ADXL345_FULL_RES);
-        setRange(getRange());
+        if (!setRange(getRange())) {
+            return false;
+        }
     }
     writeRegister(ADXL345_DATA_FORMAT, regVal);
+    return true;
 }
 
 String ADXL345_WE::getRangeAsString(){
     adxl345_range range = getRange();
     switch(range){
+        case ADXL345_RANGE_ERROR: return(F("ERROR")); break;
         case ADXL345_RANGE_2G:  return(F("2g"));   break;
         case ADXL345_RANGE_4G:  return(F("4g"));   break;
         case ADXL345_RANGE_8G:  return(F("8g"));   break;
@@ -177,42 +191,51 @@ String ADXL345_WE::getRangeAsString(){
 }
 
 uint8_t ADXL345_WE::getDeviceID(){
-    return(readRegister8(ADXL345_DEVID));
+    if (readRegister8(ADXL345_DEVID, &regVal)) {
+        return regVal;
+    } else {
+        return 0;
+    }
 }
 
 /************ x,y,z results ************/
 
-void ADXL345_WE::getRawValues(xyzFloat *rawVal){
+bool ADXL345_WE::getRawValues(xyzFloat *rawVal){
     uint8_t rawData[6]; 
-    readMultipleRegisters(ADXL345_DATAX0, 6, rawData);
+    if (!readMultipleRegisters(ADXL345_DATAX0, 6, rawData)) {
+        return false;
+    }
     rawVal->x = (static_cast<int16_t>((rawData[1] << 8) | rawData[0])) * 1.0;
     rawVal->y = (static_cast<int16_t>((rawData[3] << 8) | rawData[2])) * 1.0;
     rawVal->z = (static_cast<int16_t>((rawData[5] << 8) | rawData[4])) * 1.0;
+    return true;
 }
 
-void ADXL345_WE::getCorrectedRawValues(xyzFloat *rawVal){
-    uint8_t rawData[6]; 
-    readMultipleRegisters(ADXL345_DATAX0, 6, rawData);
-    int16_t xRaw = static_cast<int16_t>(rawData[1] << 8) | rawData[0];
-    int16_t yRaw = static_cast<int16_t>(rawData[3] << 8) | rawData[2];
-    int16_t zRaw = static_cast<int16_t>(rawData[5] << 8) | rawData[4];
-        
-    rawVal->x = xRaw * 1.0 - (offsetVal.x / rangeFactor);
-    rawVal->y = yRaw * 1.0 - (offsetVal.y / rangeFactor);
-    rawVal->z = zRaw * 1.0 - (offsetVal.z / rangeFactor);
+bool ADXL345_WE::getCorrectedRawValues(xyzFloat *rawVal){
+    if (!getRawValues(rawVal)) {
+        return false;
+    }
+    rawVal->x -= (offsetVal.x / rangeFactor);
+    rawVal->y -= (offsetVal.y / rangeFactor);
+    rawVal->z -= (offsetVal.z / rangeFactor);
+    return true;
 }
 
-void ADXL345_WE::getGValues(xyzFloat *gVal){
-    xyzFloat rawVal;
-    getCorrectedRawValues(&rawVal);
-    *gVal = rawVal * corrFact * MILLI_G_PER_LSB * rangeFactor / 1000.0; 
+bool ADXL345_WE::getGValues(xyzFloat *gVal){
+    if (!getCorrectedRawValues(gVal)) {
+        return false;
+    }
+    *gVal *= corrFact * MILLI_G_PER_LSB * rangeFactor / 1000.0; 
+    return true;
 }
 
 /************ Angles and Orientation ************/ 
 
-void ADXL345_WE::getAngles(xyzFloat *angleVal){
+bool ADXL345_WE::getAngles(xyzFloat *angleVal){
     xyzFloat gVal;
-    getGValues(&gVal);
+    if (!getGValues(&gVal)) {
+        return false;
+    }
     if(gVal.x > 1){
         gVal.x = 1;
     }
@@ -236,29 +259,35 @@ void ADXL345_WE::getAngles(xyzFloat *angleVal){
         gVal.z = -1;
     }
     angleVal->z = (asin(gVal.z)) * 57.296;
+    return true;
 }
 
-void ADXL345_WE::getCorrAngles(xyzFloat *corrAngleVal){
-    getAngles(&(*corrAngleVal));
+bool ADXL345_WE::getCorrAngles(xyzFloat *corrAngleVal){
+    if (!getAngles(corrAngleVal)) {
+        return false;
+    }
     *corrAngleVal -= angleOffsetVal;
+    return true;
 }
 
-void ADXL345_WE::measureAngleOffsets(){
-    getAngles(&angleOffsetVal);
+bool ADXL345_WE::measureAngleOffsets(){
+    return getAngles(&angleOffsetVal);
 }
 
 xyzFloat ADXL345_WE::getAngleOffsets(){
     return angleOffsetVal;
 }
 
-void ADXL345_WE::setAngleOffsets(xyzFloat aos){
+void ADXL345_WE::setAngleOffsets(const xyzFloat aos){
     angleOffsetVal = aos;
 }
 
 adxl345_orientation ADXL345_WE::getOrientation(){
     adxl345_orientation orientation = FLAT;
     xyzFloat angleVal;
-    getAngles(&angleVal);
+    if (!getAngles(&angleVal)) {
+        return ADXL345_ORIENTATION_ERROR;
+    }
     if(abs(angleVal.x) < 45){      // |x| < 45
         if(abs(angleVal.y) < 45){      // |y| < 45
             if(angleVal.z > 0){          //  z  > 0
@@ -292,6 +321,7 @@ String ADXL345_WE::getOrientationAsString(){
     adxl345_orientation orientation = getOrientation();
     String orientationAsString = "";
     switch(orientation){
+        case ADXL345_ORIENTATION_ERROR: orientationAsString = "ERROR"; break;
         case FLAT:      orientationAsString = "z up";   break;
         case FLAT_1:    orientationAsString = "z down"; break;
         case XY:        orientationAsString = "y up";   break;
@@ -304,22 +334,28 @@ String ADXL345_WE::getOrientationAsString(){
 
 float ADXL345_WE::getPitch(){
     xyzFloat gVal;
-    getGValues(&gVal);
+    if (!getGValues(&gVal)) {
+        return ADXL345_FLOAT_ERROR;
+    }
     float pitch = (atan2(-gVal.x, sqrt(abs((gVal.y*gVal.y + gVal.z*gVal.z))))*180.0)/M_PI;
     return pitch;
 }
     
 float ADXL345_WE::getRoll(){
     xyzFloat gVal;
-    getGValues(&gVal);
+    if (!getGValues(&gVal)) {
+        return ADXL345_FLOAT_ERROR;
+    }
     float roll = (atan2(gVal.y, gVal.z)*180.0)/M_PI;
     return roll;
 }
 
 /************ Power, Sleep, Standby ************/ 
 
-void ADXL345_WE::setMeasureMode(bool measure){
-    regVal = readRegister8(ADXL345_POWER_CTL);
+bool ADXL345_WE::setMeasureMode(bool measure){
+    if (!readRegister8(ADXL345_POWER_CTL, &regVal)) {
+        return false;
+    }
     if(measure){
         regVal |= (1<<ADXL345_MEASURE);
     }
@@ -327,79 +363,65 @@ void ADXL345_WE::setMeasureMode(bool measure){
         regVal &= ~(1<<ADXL345_MEASURE);
     }
     writeRegister(ADXL345_POWER_CTL, regVal);
+    return true;
 }
 
-void ADXL345_WE::setSleep(bool sleep, adxl345_wUpFreq freq){
-    regVal = readRegister8(ADXL345_POWER_CTL);
-    regVal &= 0b11111100;
-    regVal |= freq;
+bool ADXL345_WE::setSleep(bool sleep, adxl345_wUpFreq freq){
+    if (!readRegister8(ADXL345_POWER_CTL, &regVal)) {
+        return false;
+    }
+    if (freq != ADXL345_WUP_FQ_UNSET) {
+        regVal &= 0b11111100;
+        regVal |= freq;
+    }
     if(sleep){
         regVal |= (1<<ADXL345_SLEEP);
     }
     else{
-        setMeasureMode(false);  // it is recommended to enter Stand Mode when clearing the Sleep Bit!
+        // it is recommended to enter Stand Mode when clearing the Sleep Bit!
+        if (!setMeasureMode(false)) {
+            return false;
+        }
         regVal &= ~(1<<ADXL345_SLEEP);
         regVal &= ~(1<<ADXL345_MEASURE);
     }
     writeRegister(ADXL345_POWER_CTL, regVal);
     if(!sleep){
-        setMeasureMode(true);
+        setMeasureMode(true); // No return check here as the setting has been changed already
     }
-}
-
-void ADXL345_WE::setSleep(bool sleep){
-    regVal = readRegister8(ADXL345_POWER_CTL);
-    if(sleep){
-        regVal |= (1<<ADXL345_SLEEP);
-    }
-    else{
-        setMeasureMode(false);  // it is recommended to enter Stand Mode when clearing the Sleep Bit!
-        regVal &= ~(1<<ADXL345_SLEEP);
-        regVal &= ~(1<<ADXL345_MEASURE);
-    }
-    writeRegister(ADXL345_POWER_CTL, regVal);
-    if(!sleep){
-        setMeasureMode(true);
-    }
+    return true;
 }
     
-void ADXL345_WE::setAutoSleep(bool autoSleep, adxl345_wUpFreq freq){
-    if(autoSleep){
-        setLinkBit(true);
+bool ADXL345_WE::setAutoSleep(bool autoSleep, adxl345_wUpFreq freq){
+    if (!readRegister8(ADXL345_POWER_CTL, &regVal)) {
+        return false;
     }
-    regVal = readRegister8(ADXL345_POWER_CTL);
-    regVal &= 0b11111100;
-    regVal |= freq;
     if(autoSleep){
-        regVal |= (1<<ADXL345_AUTO_SLEEP);      
-    }
-    else{
+        // Both AUTO_SLEEP and LINK bits must be set
+        regVal |= (1<<ADXL345_AUTO_SLEEP) | (1<<ADXL345_LINK);
+    } else {
+        // The AUTO_SLEEP bit is cleared, but leave the LINK bit alone in case set by something else
         regVal &= ~(1<<ADXL345_AUTO_SLEEP);
+    }
+    if (freq != ADXL345_WUP_FQ_UNSET) {
+        regVal &= 0b11111100;
+        regVal |= freq;
     }
     writeRegister(ADXL345_POWER_CTL, regVal);
+    return true;
 }
         
-void ADXL345_WE::setAutoSleep(bool autoSleep){
-    if(autoSleep){
-        setLinkBit(true);
-        regVal = readRegister8(ADXL345_POWER_CTL);
-        regVal |= (1<<ADXL345_AUTO_SLEEP);
-        writeRegister(ADXL345_POWER_CTL, regVal);
-    }
-    else{
-        regVal = readRegister8(ADXL345_POWER_CTL);
-        regVal &= ~(1<<ADXL345_AUTO_SLEEP);
-        writeRegister(ADXL345_POWER_CTL, regVal);
-    }
-        
-}
-
 bool ADXL345_WE::isAsleep(){
-    return readRegister8(ADXL345_ACT_TAP_STATUS) & (1<<ADXL345_ASLEEP);
+    if (!readRegister8(ADXL345_ACT_TAP_STATUS, &regVal)) {
+        return false; // Not ideal
+    }
+    return regVal & (1<<ADXL345_ASLEEP);
 }
 
-void ADXL345_WE::setLowPower(bool lowpwr){
-    regVal = readRegister8(ADXL345_BW_RATE);
+bool ADXL345_WE::setLowPower(bool lowpwr){
+    if (!readRegister8(ADXL345_BW_RATE, &regVal)) {
+        return false;
+    }
     if(lowpwr){
         regVal |= (1<<ADXL345_LOW_POWER);
     }
@@ -407,20 +429,28 @@ void ADXL345_WE::setLowPower(bool lowpwr){
         regVal &= ~(1<<ADXL345_LOW_POWER);
     }
     writeRegister(ADXL345_BW_RATE, regVal);
+    return true;
 }
 
 bool ADXL345_WE::isLowPower(){
-    return readRegister8(ADXL345_BW_RATE) & (1<<ADXL345_LOW_POWER);
+    if (!readRegister8(ADXL345_BW_RATE, &regVal)) {
+        return false; // Not ideal
+    }
+    return regVal & (1<<ADXL345_LOW_POWER);
 }
             
 /************ Interrupts ************/
 
 
-void ADXL345_WE::setInterrupt(adxl345_int type, uint8_t pin){
-    regVal = readRegister8(ADXL345_INT_ENABLE);
+bool ADXL345_WE::setInterrupt(adxl345_int type, uint8_t pin){
+    if (!readRegister8(ADXL345_INT_ENABLE, &regVal)) {
+        return false;
+    }
     regVal |= (1<<type);
     writeRegister(ADXL345_INT_ENABLE, regVal);
-    regVal = readRegister8(ADXL345_INT_MAP);
+    if (!readRegister8(ADXL345_INT_MAP, &regVal)) {
+        return false;
+    }
     if(pin == INT_PIN_1){
         regVal &= ~(1<<type);
     }
@@ -428,10 +458,13 @@ void ADXL345_WE::setInterrupt(adxl345_int type, uint8_t pin){
         regVal |= (1<<type);
     }
     writeRegister(ADXL345_INT_MAP, regVal);
+    return true;
 }
 
-void ADXL345_WE::setInterruptPolarity(uint8_t pol){
-    regVal = readRegister8(ADXL345_DATA_FORMAT);
+bool ADXL345_WE::setInterruptPolarity(uint8_t pol){
+    if (!readRegister8(ADXL345_DATA_FORMAT, &regVal)) {
+        return false;
+    }
     if(pol == ADXL345_ACT_HIGH){
         regVal &= ~(0b00100000);
     }
@@ -439,25 +472,33 @@ void ADXL345_WE::setInterruptPolarity(uint8_t pol){
         regVal |= 0b00100000;
     }
     writeRegister(ADXL345_DATA_FORMAT, regVal);
+    return true;
 }
 
-void ADXL345_WE::deleteInterrupt(adxl345_int type){
-    regVal = readRegister8(ADXL345_INT_ENABLE);
+bool ADXL345_WE::deleteInterrupt(adxl345_int type){
+    if (!readRegister8(ADXL345_INT_ENABLE, &regVal)) {
+        return false;
+    }
     regVal &= ~(1<<type);
-    writeRegister(ADXL345_INT_ENABLE, regVal);  
+    writeRegister(ADXL345_INT_ENABLE, regVal);
+    return true;
 }
 
 uint8_t ADXL345_WE::readAndClearInterrupts(){
-    regVal = readRegister8(ADXL345_INT_SOURCE);
+    if (!readRegister8(ADXL345_INT_SOURCE, &regVal)) {
+        return 0; // Not ideal
+    }
     return regVal;
 }
 
 bool ADXL345_WE::checkInterrupt(uint8_t source, adxl345_int type){
-    source &= (1<<type);
-    return source;
+    return source & (1<<type);
 }
-void ADXL345_WE::setLinkBit(bool link){
-    regVal = readRegister8(ADXL345_POWER_CTL);
+
+bool ADXL345_WE::setLinkBit(bool link){
+    if (!readRegister8(ADXL345_POWER_CTL, &regVal)) {
+        return false;
+    }
     if(link){
         regVal |= (1<<ADXL345_LINK);
     }
@@ -465,6 +506,7 @@ void ADXL345_WE::setLinkBit(bool link){
         regVal &= ~(1<<ADXL345_LINK);
     }
     writeRegister(ADXL345_POWER_CTL, regVal);
+    return true;
 }
 
 void ADXL345_WE::setFreeFallThresholds(float ffg, float fft){
@@ -480,7 +522,7 @@ void ADXL345_WE::setFreeFallThresholds(float ffg, float fft){
     writeRegister(ADXL345_TIME_FF, regVal);
 }
 
-void ADXL345_WE::setActivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold){
+bool ADXL345_WE::setActivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold){
     regVal = static_cast<uint8_t>(round(threshold / 0.0625));
     if(regVal<1){
         regVal = 1;
@@ -488,29 +530,36 @@ void ADXL345_WE::setActivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet 
     
     writeRegister(ADXL345_THRESH_ACT, regVal);
 
-    regVal = readRegister8(ADXL345_ACT_INACT_CTL);
+    if (!readRegister8(ADXL345_ACT_INACT_CTL, &regVal)) {
+        return false;
+    }
     regVal &= 0x0F;
     regVal |= (static_cast<uint8_t>(mode) + static_cast<uint8_t>(axes))<<4;
     writeRegister(ADXL345_ACT_INACT_CTL, regVal);
+    return true;
 }
 
-void ADXL345_WE::setInactivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold, uint8_t inactTime){
+bool ADXL345_WE::setInactivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold, uint8_t inactTime){
     regVal = static_cast<uint8_t>(round(threshold / 0.0625));
     if(regVal<1){
         regVal = 1;
     }
     writeRegister(ADXL345_THRESH_INACT, regVal);
+    writeRegister(ADXL345_TIME_INACT, inactTime);
 
-    regVal = readRegister8(ADXL345_ACT_INACT_CTL);
+    if (!readRegister8(ADXL345_ACT_INACT_CTL, &regVal)) {
+        return false;
+    }
     regVal &= 0xF0;
     regVal |= static_cast<uint8_t>(mode) + static_cast<uint16_t>(axes);
     writeRegister(ADXL345_ACT_INACT_CTL, regVal);
-
-    writeRegister(ADXL345_TIME_INACT, inactTime);
+    return true;
 }
 
-void ADXL345_WE::setGeneralTapParameters(adxl345_actTapSet axes, float threshold, float duration, float latent){
-    regVal = readRegister8(ADXL345_TAP_AXES);
+bool ADXL345_WE::setGeneralTapParameters(adxl345_actTapSet axes, float threshold, float duration, float latent){
+    if (!readRegister8(ADXL345_TAP_AXES, &regVal)) {
+        return false;
+    }
     regVal &= 0b11111000;
     regVal |= static_cast<uint8_t>(axes);
     writeRegister(ADXL345_TAP_AXES, regVal);
@@ -531,11 +580,14 @@ void ADXL345_WE::setGeneralTapParameters(adxl345_actTapSet axes, float threshold
     if(regVal<1){
         regVal = 1;
     }
-    writeRegister(ADXL345_LATENT, regVal);      
+    writeRegister(ADXL345_LATENT, regVal);     
+    return true; 
 }
 
-void ADXL345_WE::setAdditionalDoubleTapParameters(bool suppress, float window){
-    regVal = readRegister8(ADXL345_TAP_AXES);
+bool ADXL345_WE::setAdditionalDoubleTapParameters(bool suppress, float window){
+    if (!readRegister8(ADXL345_TAP_AXES, &regVal)) {
+        return false;
+    }
     if(suppress){
         regVal |= (1<<ADXL345_SUPPRESS);
     }
@@ -546,20 +598,21 @@ void ADXL345_WE::setAdditionalDoubleTapParameters(bool suppress, float window){
     
     regVal = static_cast<uint8_t>(round(window / 1.25));
     writeRegister(ADXL345_WINDOW, regVal);
+    return true;
 }
 
 uint8_t ADXL345_WE::getActTapStatus(){
-    return readRegister8(ADXL345_ACT_TAP_STATUS);
+    if (!readRegister8(ADXL345_ACT_TAP_STATUS, &regVal)) {
+        return 0; // Not ideal
+    }
+    return regVal;
 }
 
 String ADXL345_WE::getActTapStatusAsString(){
-    uint8_t mask = (readRegister8(ADXL345_ACT_INACT_CTL)) & 0b01110000;
-    mask |= ((readRegister8(ADXL345_TAP_AXES)) & 0b00000111);
-        
+    if (!readRegister8(ADXL345_ACT_TAP_STATUS, &regVal)) {
+        return String("ERROR");
+    }
     String returnStr = "";
-    regVal = readRegister8(ADXL345_ACT_TAP_STATUS); 
-    regVal &= mask;
-        
     if(regVal & (1<<ADXL345_TAP_Z)) { returnStr += "TAP-Z "; }
     if(regVal & (1<<ADXL345_TAP_Y)) { returnStr += "TAP-Y "; }
     if(regVal & (1<<ADXL345_TAP_X)) { returnStr += "TAP-X "; }
@@ -572,30 +625,38 @@ String ADXL345_WE::getActTapStatusAsString(){
 
 /************ FIFO ************/
 
-void ADXL345_WE::setFifoParameters(adxl345_triggerInt intNumber, uint8_t samples){
-    regVal = readRegister8(ADXL345_FIFO_CTL);
+bool ADXL345_WE::setFifoParameters(adxl345_triggerInt intNumber, uint8_t samples){
+    if (!readRegister8(ADXL345_FIFO_CTL, &regVal)) {
+        return false;
+    }
     regVal &= 0b11000000;
     regVal |= (samples-1);
     if(intNumber == ADXL345_TRIGGER_INT_2){
         regVal |= 0x20;
     }
     writeRegister(ADXL345_FIFO_CTL, regVal);
+    return true;
 }
 
-void ADXL345_WE::setFifoMode(adxl345_fifoMode mode){
-    regVal = readRegister8(ADXL345_FIFO_CTL);
+bool ADXL345_WE::setFifoMode(adxl345_fifoMode mode){
+    if (!readRegister8(ADXL345_FIFO_CTL, &regVal)) {
+        return false;
+    }
     regVal &= 0b00111111;
     regVal |= (mode<<6);
     writeRegister(ADXL345_FIFO_CTL,regVal);
+    return true;
 }
 
 uint8_t ADXL345_WE::getFifoStatus(){
-    return readRegister8(ADXL345_FIFO_STATUS);
+    if (!readRegister8(ADXL345_FIFO_STATUS, &regVal)) {
+        return 0; // Not ideal
+    }
+    return regVal;
 }
 
-void ADXL345_WE::resetTrigger(){
-    setFifoMode(ADXL345_BYPASS);
-    setFifoMode(ADXL345_TRIGGER);
+bool ADXL345_WE::resetTrigger(){
+    return setFifoMode(ADXL345_BYPASS) && setFifoMode(ADXL345_TRIGGER);
 }
 
 
@@ -603,13 +664,12 @@ void ADXL345_WE::resetTrigger(){
     private functions
 *************************************************/
 
-uint8_t ADXL345_WE::writeRegister(uint8_t reg, uint8_t val){
+void ADXL345_WE::writeRegister(uint8_t reg, uint8_t val){
     if(!useSPI){
         _wire->beginTransmission(i2cAddress);
         _wire->write(reg);
         _wire->write(val);
-  
-        return _wire->endTransmission();
+        _wire->endTransmission();    
     }
     else{
         _spi->beginTransaction(mySPISettings);
@@ -619,20 +679,23 @@ uint8_t ADXL345_WE::writeRegister(uint8_t reg, uint8_t val){
         _spi->transfer(val);
         digitalWrite(csPin, HIGH);
         _spi->endTransaction();
-        return false; // to be amended
     }
 }
   
-uint8_t ADXL345_WE::readRegister8(uint8_t reg){
-    uint8_t regValue = 0;
+bool ADXL345_WE::readRegister8(uint8_t reg, uint8_t *val){
     if(!useSPI){    
+        bool ok = true;
         _wire->beginTransmission(i2cAddress);
-        _wire->write(reg);
-        _wire->endTransmission(false);
+        ok &= (_wire->write(reg) == 1);
+        ok &= (_wire->endTransmission(false) == 0);
         _wire->requestFrom(i2cAddress, static_cast<uint8_t>(1));
-        if(_wire->available()){
-            regValue = _wire->read();
-        }
+        if(ok && _wire->available()){
+            // Success
+            *val = _wire->read();
+            return true;
+        } 
+        // No response
+        return false;
     }
     else{
         reg |= 0x80;
@@ -640,22 +703,29 @@ uint8_t ADXL345_WE::readRegister8(uint8_t reg){
         digitalWrite(csPin, LOW);
         delayMicroseconds(5);
         _spi->transfer(reg); 
-        regValue = _spi->transfer(0x00);
+        *val = _spi->transfer(0x00);
         digitalWrite(csPin, HIGH);
         _spi->endTransaction();
+        return true; // Error checking is not possible with SPI
     }
-    return regValue;
 }
 
-void ADXL345_WE::readMultipleRegisters(uint8_t reg, uint8_t count, uint8_t *buf){
+bool ADXL345_WE::readMultipleRegisters(uint8_t reg, uint8_t count, uint8_t *buf){
     if(!useSPI){
+        bool ok = true;
         _wire->beginTransmission(i2cAddress);
-        _wire->write(reg);
-        _wire->endTransmission(false);
-        _wire->requestFrom(i2cAddress,count);
-        for(int i=0; i<count; i++){
-            buf[i] = _wire->read();
-        }    
+        ok &= (_wire->write(reg) == 1);
+        ok &= (_wire->endTransmission(false) == 0);
+        _wire->requestFrom(i2cAddress, count);
+        if (ok && _wire->available() == count) {
+            // Success
+            for(int i=0; i<count; i++){
+                buf[i] = _wire->read();
+            }
+            return true;
+        }
+        // No response, or incomplete response
+        return false;
     }
     else{
         reg = reg | 0x80;
@@ -669,6 +739,7 @@ void ADXL345_WE::readMultipleRegisters(uint8_t reg, uint8_t count, uint8_t *buf)
         }
         digitalWrite(csPin, HIGH);
         _spi->endTransaction();
+        return true; // Error checking is not possible with SPI
     }
 }
 

--- a/src/ADXL345_WE.h
+++ b/src/ADXL345_WE.h
@@ -38,6 +38,9 @@ constexpr uint8_t ADXL345_ACT_HIGH {0x00};
 #define ADXL343_ACT_LOW ADXL_345_ACT_LOW
 #define ADXL343_ACT_HIGH ADXL345_ACT_HIGH
 
+constexpr float ADXL345_FLOAT_ERROR {999.0}; // Returned by getPitch() and getRoll() to indicate error
+constexpr float ADXL343_FLOAT_ERROR {ADXL345_FLOAT_ERROR};
+
 typedef enum ADXL345_PWR_CTL {
     ADXL345_WAKE_UP_0, ADXL345_WAKE_UP_1, ADXL345_SLEEP, 
     ADXL345_MEASURE, ADXL345_AUTO_SLEEP, ADXL345_LINK,
@@ -49,18 +52,8 @@ typedef enum ADXL345_PWR_CTL {
     ADXL343_LINK       = ADXL345_LINK
 } adxl345_pwrCtl;
 
-typedef enum ADXL345_WAKE_UP { // belongs to POWER CTL
-    ADXL345_WAKE_UP_FREQ_8,
-    ADXL345_WAKE_UP_FREQ_4,
-    ADXL345_WAKE_UP_FREQ_2,
-    ADXL345_WAKE_UP_FREQ_1,
-    ADXL343_WAKE_UP_FREQ_8 = ADXL345_WAKE_UP_FREQ_8,
-    ADXL343_WAKE_UP_FREQ_4 = ADXL345_WAKE_UP_FREQ_4,
-    ADXL343_WAKE_UP_FREQ_2 = ADXL345_WAKE_UP_FREQ_2,
-    ADXL343_WAKE_UP_FREQ_1 = ADXL345_WAKE_UP_FREQ_1
-} adxl345_wakeUpFreq;
-
 typedef enum ADXL345_DATA_RATE {
+    ADXL345_DATA_RATE_ERROR   = -1, // returned on read error, cannot be set
     ADXL345_DATA_RATE_3200    = 0x0F,
     ADXL345_DATA_RATE_1600    = 0x0E,
     ADXL345_DATA_RATE_800     = 0x0D,
@@ -77,6 +70,7 @@ typedef enum ADXL345_DATA_RATE {
     ADXL345_DATA_RATE_0_39    = 0x02,
     ADXL345_DATA_RATE_0_20    = 0x01,
     ADXL345_DATA_RATE_0_10    = 0x00,
+    ADXL343_DATA_RATE_ERROR   = ADXL345_DATA_RATE_ERROR,
     ADXL343_DATA_RATE_3200    = ADXL345_DATA_RATE_3200,
     ADXL343_DATA_RATE_1600    = ADXL345_DATA_RATE_1600,
     ADXL343_DATA_RATE_800     = ADXL345_DATA_RATE_800,
@@ -96,10 +90,12 @@ typedef enum ADXL345_DATA_RATE {
 } adxl345_dataRate;
 
 typedef enum ADXL345_RANGE {
+    ADXL345_RANGE_ERROR        = -1, // returned on read error, cannot be set
     ADXL345_RANGE_16G          = 0b11,
     ADXL345_RANGE_8G           = 0b10,
     ADXL345_RANGE_4G           = 0b01,
     ADXL345_RANGE_2G           = 0b00,
+    ADXL343_RANGE_ERROR        = ADXL345_RANGE_ERROR,
     ADXL343_RANGE_16G          = ADXL345_RANGE_16G,
     ADXL343_RANGE_8G           = ADXL345_RANGE_8G,
     ADXL343_RANGE_4G           = ADXL345_RANGE_4G,
@@ -107,7 +103,9 @@ typedef enum ADXL345_RANGE {
 } adxl345_range;
 
 typedef enum ADXL345_ORIENTATION {
-  FLAT, FLAT_1, XY, XY_1, YX, YX_1
+  ADXL345_ORIENTATION_ERROR = -1, // returned on read error
+  ADXL343_ORIENTATION_ERROR = ADXL345_ORIENTATION_ERROR,
+  FLAT = 0, FLAT_1, XY, XY_1, YX, YX_1
 } adxl345_orientation;
 
 typedef enum ADXL345_INT {
@@ -144,7 +142,9 @@ typedef enum ADXL345_DC_AC {
 } adxl345_dcAcMode;
 
 typedef enum ADXL345_WAKE_UP_FREQ{
-    ADXL345_WUP_FQ_8, ADXL345_WUP_FQ_4, ADXL345_WUP_FQ_2, ADXL345_WUP_FQ_1,
+    ADXL345_WUP_FQ_UNSET = -1,
+    ADXL345_WUP_FQ_8 = 0, ADXL345_WUP_FQ_4, ADXL345_WUP_FQ_2, ADXL345_WUP_FQ_1,
+    ADXL343_WUP_FQ_UNSET = ADXL345_WUP_FQ_UNSET,
     ADXL343_WUP_FQ_8 = ADXL345_WUP_FQ_8,
     ADXL343_WUP_FQ_4 = ADXL345_WUP_FQ_4,
     ADXL343_WUP_FQ_2 = ADXL345_WUP_FQ_2,
@@ -241,29 +241,29 @@ class ADXL345_WE
         bool init();
         void setSPIClockSpeed(unsigned long clock);
         void setCorrFactors(float xMin, float xMax, float yMin, float yMax, float zMin, float zMax);
-        void setDataRate(adxl345_dataRate rate);
+        bool setDataRate(adxl345_dataRate rate);
         adxl345_dataRate getDataRate();
         String getDataRateAsString();
         uint8_t getPowerCtlReg();
-        void setRange(adxl345_range range);
+        bool setRange(adxl345_range range);
         adxl345_range getRange();
-        void setFullRes(bool full);
+        bool setFullRes(bool full);
         String getRangeAsString();
         uint8_t getDeviceID();
         
         /* x,y,z results */
             
-        void getRawValues(xyzFloat *rawVal);
-        void getCorrectedRawValues(xyzFloat *rawVal);
-        void getGValues(xyzFloat *gVal);
+        bool getRawValues(xyzFloat *rawVal);
+        bool getCorrectedRawValues(xyzFloat *rawVal);
+        bool getGValues(xyzFloat *gVal);
             
         /* Angles and Orientation */ 
         
-        void getAngles(xyzFloat *angleVal);
-        void getCorrAngles(xyzFloat *corrAngleVal);
-        void measureAngleOffsets();
+        bool getAngles(xyzFloat *angleVal);
+        bool getCorrAngles(xyzFloat *corrAngleVal);
+        bool measureAngleOffsets();
         xyzFloat getAngleOffsets();
-        void setAngleOffsets(xyzFloat aos);
+        void setAngleOffsets(const xyzFloat aos);
         adxl345_orientation getOrientation();
         String getOrientationAsString();
         float getPitch();
@@ -271,37 +271,35 @@ class ADXL345_WE
         
         /* Power, Sleep, Standby */ 
         
-        void setMeasureMode(bool measure);
-        void setSleep(bool sleep, adxl345_wUpFreq freq);
-        void setSleep(bool sleep);
-        void setAutoSleep(bool autoSleep, adxl345_wUpFreq freq);
-        void setAutoSleep(bool autoSleep);
+        bool setMeasureMode(bool measure);
+        bool setSleep(bool sleep, adxl345_wUpFreq freq = ADXL345_WUP_FQ_UNSET);
+        bool setAutoSleep(bool autoSleep, adxl345_wUpFreq freq = ADXL345_WUP_FQ_UNSET);
         bool isAsleep();
-        void setLowPower(bool lowpwr);
+        bool setLowPower(bool lowpwr);
         bool isLowPower();
         
         /* Interrupts */
         
-        void setInterrupt(adxl345_int type, uint8_t pin);
-        void setInterruptPolarity(uint8_t pol);
-        void deleteInterrupt(adxl345_int type);
+        bool setInterrupt(adxl345_int type, uint8_t pin);
+        bool setInterruptPolarity(uint8_t pol);
+        bool deleteInterrupt(adxl345_int type);
         uint8_t readAndClearInterrupts();
         bool checkInterrupt(uint8_t source, adxl345_int type);
-        void setLinkBit(bool link);
+        bool setLinkBit(bool link);
         void setFreeFallThresholds(float ffg, float fft);
-        void setActivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold);
-        void setInactivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold, uint8_t inactTime);
-        void setGeneralTapParameters(adxl345_actTapSet axes, float threshold, float duration, float latent);
-        void setAdditionalDoubleTapParameters(bool suppress, float window);
+        bool setActivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold);
+        bool setInactivityParameters(adxl345_dcAcMode mode, adxl345_actTapSet axes, float threshold, uint8_t inactTime);
+        bool setGeneralTapParameters(adxl345_actTapSet axes, float threshold, float duration, float latent);
+        bool setAdditionalDoubleTapParameters(bool suppress, float window);
         uint8_t getActTapStatus();
         String getActTapStatusAsString();
         
         /* FIFO */
         
-        void setFifoParameters(adxl345_triggerInt intNumber, uint8_t samples);
-        void setFifoMode(adxl345_fifoMode mode);
+        bool setFifoParameters(adxl345_triggerInt intNumber, uint8_t samples);
+        bool setFifoMode(adxl345_fifoMode mode);
         uint8_t getFifoStatus();
-        void resetTrigger();
+        bool resetTrigger();
        
     protected:
         TwoWire *_wire;
@@ -320,9 +318,9 @@ class ADXL345_WE
         int sckPin;  
         int sensorID;
         float rangeFactor;
-        uint8_t writeRegister(uint8_t reg, uint8_t val);
-        uint8_t readRegister8(uint8_t reg);
-        void readMultipleRegisters(uint8_t reg, uint8_t count, uint8_t *buf);
+        void writeRegister(uint8_t reg, uint8_t val);
+        bool readRegister8(uint8_t reg, uint8_t *val);
+        bool readMultipleRegisters(uint8_t reg, uint8_t count, uint8_t *buf);
         bool adxl345_lowRes;
 };
 


### PR DESCRIPTION
* `readRegister8()` and `readMultipleRegisters()` now return `bool` to indicate success or failure.  `readRegister8()` therefore now takes a pointer to a `uint8_t` which is where the actual value read will be placed - this value must be ignored if the function returned false. Error checking only applies to I2C; with SPI meaningful checks are impossible and the functions always return true.

* Functions that read registers and previously had a `void` return type also now return `bool` to indicate the success or failure of those register reads. As well as many `get*` functions this includes some `set*` functions where a register's existing value is being modified and therefore a successful read is required.

* To avoid breaking changes, functions that read registers and had a non-`void` return type have an unchanged prototype, but where possible they return a special value to indicate an error, that would not normally be returned from a successful read. In the case of enum return types, an `ERROR` value has been added to each of the enums (e.g. `ADXL345_DATA_RATE_ERROR`, `ADXL345_RANGE_ERROR` etc). Setters that take these enums will refused to set this value. In the case of float return types (`getPitch()` and `getRoll()`) the value `ADXL345_FLOAT_ERROR`(-999.0) is returned.

* `writeRegister()` is now a `void` return type. Its former `uint8_t` return value was not actually checked anywhere, and although it could have been checked (only when using I2C), in practice the circumstances in which a register write would fail noticeably are very rare, and trying to check every time would be a massive pain. Checking register **reads** is more likely to show up comms/part failures.

* `setSleep()` and `setAutoSleep()` each had two nearly identical versions, one with and one without a frequency parameter. I have merged these into one function for each, which can be called with or without frequency by using a default value which skips the frequency setting if it was not supplied. This is just to eliminate duplicate code.

* Removed the masking in `getActTapStatusAsString()` as it seemed pointless - ACT_TAP_STATUS will only set an axis's bit if it was enabled in the first place, so there should be no need to mask it against the enabled axes.  Plus `getActTapStatus()` didn't do that.

* Removed unused `typedef enum ADXL345_WAKE_UP {...} adxl345_wakeUpFreq`; it was a duplicate of `typedef enum ADXL345_WAKE_UP_FREQ {...} adxl345_wUpFreq`, which is actually used.